### PR TITLE
Add support for the cmake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,6 @@ add_executable(peldd
 set_property(TARGET peldd PROPERTY INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/pe-parse)
 target_link_libraries(peldd pe-parser-library ${Boost_LIBRARIES})
+
+install(TARGETS peldd
+        RUNTIME DESTINATION bin)


### PR DESCRIPTION
Having a consistent install target helps others to use your tool (for packaging, for example).
