### PR TITLE
Drop requirement on boost by using C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,8 @@
-cmake_minimum_required(VERSION 2.8.8...3.22.1)
+cmake_minimum_required(VERSION 3.1...3.22.1)
 project(mingw_util CXX)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
-if(MINGW)
-    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-	set(Boost_ARCHITECTURE "-x64")
-    else()
-	set(Boost_ARCHITECTURE "-x32")
-    endif()
-endif()
-
-# set(Boost_DEBUG ON)
-
-find_package(Boost 1.54
-    REQUIRED COMPONENTS
-    system      # needed by filesystem
-    filesystem)
+set(CMAKE_CXX_STANDARD 17)
+add_compile_options("-Wall")
 
 add_executable(peldd
   peldd.cc
@@ -24,7 +11,6 @@ add_executable(peldd
   )
 set_property(TARGET peldd PROPERTY INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/pe-parse/pe-parser-library/include)
-target_link_libraries(peldd ${Boost_LIBRARIES})
 
 install(TARGETS peldd
         RUNTIME DESTINATION bin)


### PR DESCRIPTION
Drops the requirement on boost by upping the C++ standard to C++17.

Simplifies deployment and packaging.